### PR TITLE
feat: add worktree-status plugin for git state monitoring

### DIFF
--- a/worktree-status.ts
+++ b/worktree-status.ts
@@ -1,0 +1,43 @@
+import type { Plugin } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin";
+import { spawnSync } from "child_process";
+
+export const WorktreeStatusPlugin: Plugin = async (ctx) => {
+  const { directory, client } = ctx;
+
+  return {
+    tool: {
+      worktree_status: tool({
+        description:
+          "Check the current worktree state: dirty, busy, branch status, and active sessions.",
+        args: {},
+        async execute() {
+          // Check if the worktree is dirty using git status
+          const gitStatus = spawnSync("git", ["status", "--porcelain"], {
+            cwd: directory,
+            encoding: "utf-8",
+          });
+          
+          // Get the current branch name
+          const branchResult = spawnSync("git", ["branch", "--show-current"], {
+            cwd: directory,
+            encoding: "utf-8",
+          });
+
+          // List active OpenCode sessions
+          const sessionsResult = await client.session.list({ query: { directory } });
+
+          // Return the status as a JSON object
+          return JSON.stringify({
+            dirty: (gitStatus.stdout || "").trim().length > 0,
+            busy: (sessionsResult.data || []).filter(
+              (s) => s.directory === directory
+            ).length > 1,
+            currentBranch: (branchResult.stdout || "").trim(),
+          });
+        },
+      }),
+    },
+  };
+};
+export default WorktreeStatusPlugin;


### PR DESCRIPTION
## Summary
- Adds new `worktree-status.ts` plugin that provides a `worktree_status` tool
- Checks git dirty state, active sessions, and current branch
- Supports Issue #6 (Worktree Auto-Switch with Agent-Driven Detection)

## Changes
- New plugin file: `worktree-status.ts`
- Uses Node.js `child_process.spawnSync` for git commands (portable across Node/Bun)
- Integrates with OpenCode SDK to list active sessions

## Tool Output
```json
{
  "dirty": true/false,
  "busy": true/false,
  "currentBranch": "main"
}
```

## Testing
- Deploy to `~/.config/opencode/plugin/` and restart OpenCode
- The agent can call `worktree_status` tool to check git state

Closes #6 (partial - provides the status checking component)