### PR TITLE
fix(reflection): use all human messages as input task

### DIFF
--- a/reflection.ts
+++ b/reflection.ts
@@ -265,9 +265,9 @@ export const ReflectionPlugin: Plugin = async ({ client, directory }) => {
 
     // Build task representation from ALL human messages
     // If only one message, use it directly; otherwise format as numbered conversation history
-    const originalTask = humanMessages[0] || ""
+    // NOTE: This ensures the judge evaluates against the EVOLVING task, not just the first message
     const task = humanMessages.length === 1
-      ? originalTask
+      ? humanMessages[0]
       : humanMessages.map((msg, i) => `[${i + 1}] ${msg}`).join("\n\n")
     
     // Detect research-only tasks (check all human messages, not just first)
@@ -276,7 +276,7 @@ export const ReflectionPlugin: Plugin = async ({ client, directory }) => {
                        /do not|don't|no code|research only|just research|only research/i.test(allHumanText)
 
     debug("extractTaskAndResult - humanMessages:", humanMessages.length, "task empty?", !task, "result empty?", !result, "isResearch?", isResearch)
-    if (!originalTask || !result) return null
+    if (!task || !result) return null
     return { task, result, tools: tools.slice(-10).join("\n"), isResearch, humanMessages }
   }
 


### PR DESCRIPTION
## Summary
Fixes issue where reflection was only evaluating against the first user message (`originalTask`), ignoring subsequent pivots or clarifications.

## Changes
- Removed `originalTask` variable
- Updated logic to use `task` (which already contains either the single message or the numbered list of ALL messages) as the primary input for validation
- Ensures `extractTaskAndResult` returns valid task context even if the first message wasn't the "main" one (though it still requires *some* task content)

## Reason
Users often pivot during a session (e.g., "actually, do X instead"). The judge needs the full conversation context, not just the initial prompt, to correctly evaluate if the *current* goal was met.

## Testing
- [x] TypeScript check passes
- [x] Unit tests pass
- [x] Deployed to local config and verified