### PR TITLE
fix(reflection): detect and nudge stuck agent after tool call or compression

### DIFF
--- a/reflection.ts
+++ b/reflection.ts
@@ -268,9 +268,9 @@ export const ReflectionPlugin: Plugin = async ({ client, directory }) => {
 
     // Build task representation from ALL human messages
     // If only one message, use it directly; otherwise format as numbered conversation history
-    const originalTask = humanMessages[0] || ""
+    // NOTE: This ensures the judge evaluates against the EVOLVING task, not just the first message
     const task = humanMessages.length === 1
-      ? originalTask
+      ? humanMessages[0]
       : humanMessages.map((msg, i) => `[${i + 1}] ${msg}`).join("\n\n")
     
     // Detect research-only tasks (check all human messages, not just first)
@@ -279,7 +279,7 @@ export const ReflectionPlugin: Plugin = async ({ client, directory }) => {
                        /do not|don't|no code|research only|just research|only research/i.test(allHumanText)
 
     debug("extractTaskAndResult - humanMessages:", humanMessages.length, "task empty?", !task, "result empty?", !result, "isResearch?", isResearch)
-    if (!originalTask || !result) return null
+    if (!task || !result) return null
     return { task, result, tools: tools.slice(-10).join("\n"), isResearch, humanMessages }
   }
 


### PR DESCRIPTION
## Summary

This PR consolidates two reflection layer fixes:

1. **Stuck agent detection** (Issue #30) - Fixes agent getting stuck mid-turn after tool call returns, especially after context compression
2. **All human messages evaluation** (Issue #16, PR #29) - Fixes reflection only evaluating first user message, ignoring subsequent pivots

## Changes

### Stuck Agent Detection (`isLastMessageStuck()`)
- Detects when assistant message was created but never completed
- Checks for 0 output tokens and no completion time after 60 seconds
- Adds startup check (`checkAllSessionsOnStartup()`) for `-c` continue sessions
- Compression handler now retries up to 5 times (every 15s) if agent is busy
- Uses stuck message detection as fallback

### All Human Messages Evaluation
- Removed `originalTask` variable
- Uses `task` (all messages combined) for validation check
- Ensures judge evaluates against the EVOLVING task after user pivots

## Why Previous Stuck Fixes Failed

The old compression logic:
```typescript
setTimeout(async () => {
  if (!(await isSessionIdle(sessionId))) {
    return  // BUG: Agent is busy, so we skip the nudge
  }
  await nudgeSession(sessionId, "compression")
}, 3000)
```

Agent was busy immediately after compression (processing summary), so nudge was skipped and never retried.

## Testing

- [x] TypeScript compiles (`npm run typecheck`)
- [x] Unit tests pass (54 tests, 5 skipped)
- [x] Plugin deployed to `~/.config/opencode/plugin/`

## Fixes

- Fixes #30 (stuck agent after tool call)
- Fixes #16 (summary instead of execution - improved evaluation)
- Supersedes PR #29

## Related

- Issue #12, #14 - Previous reports of stuck agent