### PR TITLE
fix(telegram): track failed reply deliveries when session no longer exists

### DIFF
--- a/supabase/migrations/20240120000000_add_processed_error.sql
+++ b/supabase/migrations/20240120000000_add_processed_error.sql
@@ -1,0 +1,37 @@
+-- Add processed_error column to track delivery failures
+-- This allows us to mark messages as processed (preventing duplicates)
+-- while still tracking which ones failed to deliver
+
+ALTER TABLE telegram_replies
+ADD COLUMN IF NOT EXISTS processed_error TEXT DEFAULT NULL;
+
+-- Add comment explaining the field
+COMMENT ON COLUMN telegram_replies.processed_error IS 
+  'Error message when reply processing failed (e.g., session_not_found). NULL means success.';
+
+-- Create index for finding failed deliveries
+CREATE INDEX IF NOT EXISTS idx_telegram_replies_processed_error 
+  ON telegram_replies(processed_error) 
+  WHERE processed_error IS NOT NULL;
+
+-- Create function to set error on a reply
+-- Used when reply processing fails (e.g., session no longer exists)
+CREATE OR REPLACE FUNCTION public.set_reply_error(p_reply_id UUID, p_error TEXT)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  UPDATE public.telegram_replies
+  SET 
+    processed_error = p_error
+  WHERE id = p_reply_id;
+  
+  RETURN FOUND;
+END;
+$$;
+
+-- Grant execute on the function to anon role
+GRANT EXECUTE ON FUNCTION public.set_reply_error(UUID, TEXT) TO anon;
+
+COMMENT ON FUNCTION public.set_reply_error IS 'Records an error for a telegram reply that failed to process. Called by OpenCode plugin when session is not found.';


### PR DESCRIPTION
## Summary
- Adds `processed_error` column to track delivery failures (e.g., `session_not_found`)
- Adds `set_reply_error` RPC function for secure error recording
- Shows specific toast notification for orphaned replies ("Session Gone" warning)

## Problem
When a Telegram reply arrived but the target session no longer existed, the reply was marked as `processed: true` to prevent duplicate handling, but the delivery failure was lost. Users had to repeat themselves if the session was closed before their reply arrived.

**Example (from yesterday):**
- Voice message ID: `6088dc4d-d433-471c-92aa-005ccddfb698`
- Transcription: "Merge" (user asking to merge PR #28)
- Session: `ses_3fe71fdfaffeQaN1HAaTfCEtIJ` (no longer exists)
- Result: Message lost

## Solution
1. Add `processed_error` column to record why a reply failed to deliver
2. Detect session-not-found errors specifically with `isSessionNotFoundError()`
3. Record errors in database via new `set_reply_error` RPC function
4. Show specific toast: "Session Gone - Session ses_xxx... no longer exists"

The reply is still marked as processed to prevent duplicate processing across multiple OpenCode instances, but the error is now preserved for audit.

## Files Changed
- `tts.ts` - Error handling in real-time handler and recovery function
- `test/tts.test.ts` - Unit tests for error detection logic
- `supabase/migrations/20240120000000_add_processed_error.sql` - New column and RPC function

## Testing
- [x] `npm run typecheck` passes
- [x] `npm test` - 94 tests pass (including new session-not-found tests)
- [x] Migration applied to Supabase and RPC function works

Fixes #36