### PR TITLE
fix: remove console.error calls that corrupt the OpenCode TUI

### DIFF
--- a/github.ts
+++ b/github.ts
@@ -49,11 +49,8 @@ const CONFIG_PATH = join(homedir(), ".config", "opencode", "github.json")
 const ISSUE_FILE = ".github-issue.md"
 const MAX_COMMENT_LENGTH = 65000 // GitHub's limit is 65536
 
-// Debug logging
-const DEBUG = process.env.GITHUB_DEBUG === "1"
-function debug(...args: any[]) {
-  if (DEBUG) console.error("[GitHub]", ...args)
-}
+// Debug logging (silenced — console.error corrupts the OpenCode TUI)
+function debug(..._args: any[]) {}
 
 // ==================== CONFIG LOADING ====================
 

--- a/reflection-3.ts
+++ b/reflection-3.ts
@@ -78,15 +78,13 @@ interface ReflectionAnalysis {
   severity: "NONE" | "LOW" | "MEDIUM" | "HIGH" | "BLOCKER"
 }
 
-const DEBUG = process.env.REFLECTION_DEBUG === "1"
 const JUDGE_RESPONSE_TIMEOUT = 120_000
 const POLL_INTERVAL = 2_000
 const ABORT_COOLDOWN = 10_000
 const REFLECTION_CONFIG_PATH = join(homedir(), ".config", "opencode", "reflection.yaml")
 
-function debug(...args: any[]) {
-  if (DEBUG) console.error("[Reflection3]", ...args)
-}
+// Debug logging (silenced — console.error corrupts the OpenCode TUI)
+function debug(..._args: any[]) {}
 
 async function loadReflectionPrompt(directory: string): Promise<string | null> {
   const candidates = ["reflection.md", "reflection.MD"]

--- a/telegram.ts
+++ b/telegram.ts
@@ -75,11 +75,8 @@ const DEFAULT_WHISPER_URL = "http://127.0.0.1:8000"
 const REFLECTION_VERDICT_WAIT_MS = 10_000
 const REFLECTION_POLL_INTERVAL_MS = 250
 
-// Debug logging
-const DEBUG = process.env.TELEGRAM_DEBUG === "1"
-async function debug(msg: string) {
-  if (DEBUG) console.error(`[Telegram] ${msg}`)
-}
+// Debug logging (silenced — console.error corrupts the OpenCode TUI)
+async function debug(_msg: string) {}
 
 // ==================== CONFIG LOADING ====================
 
@@ -136,7 +133,7 @@ async function isFfmpegAvailable(): Promise<boolean> {
 
 async function convertWavToOgg(wavPath: string): Promise<string | null> {
   if (!wavPath || typeof wavPath !== 'string') {
-    console.error('[Telegram] convertWavToOgg called with invalid wavPath:', typeof wavPath, wavPath)
+    // silent — console.error corrupts the OpenCode TUI
     return null
   }
   
@@ -217,7 +214,7 @@ async function sendNotification(
 
         if (oggPath) await unlink(oggPath).catch(() => {})
       } catch (err) {
-        console.error("[Telegram] Failed to read voice file:", err)
+        // silent — console.error corrupts the OpenCode TUI
       }
     }
 
@@ -833,7 +830,7 @@ export const TelegramPlugin: Plugin = async ({ client, directory }) => {
       supabaseClient = createClient(supabaseUrl, supabaseKey, {})
       return supabaseClient
     } catch {
-      console.error('[Telegram] Install @supabase/supabase-js to enable reply subscription')
+      // silent — console.error corrupts the OpenCode TUI
       return null
     }
   }

--- a/tts.ts
+++ b/tts.ts
@@ -76,7 +76,7 @@ async function triggerGlobalStop(): Promise<void> {
     });
     await writeFile(TTS_STOP_SIGNAL_PATH, content);
   } catch (e) {
-    console.error("[TTS] Failed to create stop signal:", e);
+    // silent — console.error corrupts the OpenCode TUI
   }
 }
 
@@ -161,7 +161,7 @@ async function execAndTrack(command: string): Promise<void> {
         currentPlaybackProcess = null;
       }
       // Log error but resolve to prevent crashing the plugin
-      console.error("[TTS] Audio playback error:", err);
+      // silent — console.error corrupts the OpenCode TUI
       resolve();
     });
   });
@@ -395,7 +395,7 @@ async function saveConfig(config: TTSConfig): Promise<void> {
     await mkdir(configDir, { recursive: true })
     await writeFile(TTS_CONFIG_PATH, JSON.stringify(config, null, 2))
   } catch (e) {
-    console.error("[TTS] Failed to save config:", e)
+    // silent — console.error corrupts the OpenCode TUI
   }
 }
 

--- a/worktree.ts
+++ b/worktree.ts
@@ -234,7 +234,7 @@ This enables parallel development on multiple branches with separate TUI windows
             } catch (e: any) {
               // Session creation failed - might not be running as server
               // Still create worktree, just won't have pre-created session
-              console.error(`[Worktree] Could not create session: ${e.message}`);
+              // silent — console.error corrupts the OpenCode TUI
             }
             
             // 4. Launch terminal with opencode attach (macOS only)


### PR DESCRIPTION
## Summary
- Remove all `console.error` / `console.log` calls from plugin files that corrupt the OpenCode terminal UI
- Both stdout and stderr output from plugins interferes with the TUI rendering
- Per [OpenCode plugin docs](https://opencode.ai/docs/plugins/#logging), plugins should use `client.app.log()` instead of `console.*`

## Changes
| Plugin | Calls removed | Details |
|--------|--------------|---------|
| `reflection-3.ts` | 1 | `debug()` function + unused `DEBUG` const |
| `tts.ts` | 3 | Error handlers in `triggerGlobalStop`, `execAndTrack`, `saveConfig` |
| `telegram.ts` | 4 | `debug()` function + 3 error handlers + unused `DEBUG` const |
| `github.ts` | 1 | `debug()` function + unused `DEBUG` const |
| `worktree.ts` | 1 | Error handler in `worktree_create` |

## Testing
- `npm run typecheck` -- pass
- `npm test` -- 162 passed, 0 failures