### PR TITLE
fix: reflection-3 stuck on non-coding tasks due to ops misclassification

### DIFF
--- a/reflection-3.test-helpers.ts
+++ b/reflection-3.test-helpers.ts
@@ -66,7 +66,11 @@ export interface ReflectionAnalysis {
 export function inferTaskType(text: string): TaskType {
   if (/research|investigate|analyze|compare|evaluate|study/i.test(text)) return "research"
   if (/docs?|readme|documentation/i.test(text)) return "docs"
+  // Ops detection: explicit ops terms and personal-assistant / browser-automation patterns
+  // Must be checked BEFORE coding to avoid "create filter" or "build entities" matching as coding
   if (/deploy|release|infra|ops|oncall|incident|runbook/i.test(text)) return "ops"
+  if (/\bgmail\b|\bemail\b|\bfilter\b|\binbox\b|\bcalendar\b|\blinkedin\b|\brecruiter\b|\bbrowser\b/i.test(text)) return "ops"
+  if (/\bclean\s*up\b|\borganize\b|\bconfigure\b|\bsetup\b|\bset\s*up\b|\binstall\b/i.test(text)) return "ops"
   if (/fix|bug|issue|error|regression/i.test(text)) return "coding"
   if (/implement|add|create|build|feature|refactor|improve|update/i.test(text)) return "coding"
   return "other"
@@ -246,7 +250,13 @@ export function evaluateSelfAssessment(assessment: SelfAssessment, context: Task
   }
 
   const requiresHumanAction = needsUserAction.length > 0
-  const shouldContinue = !requiresHumanAction && missing.length > 0
+  // Agent should continue if there are missing items beyond what only the user can do.
+  // Even when user action is needed (e.g. "merge PR"), the agent may still have
+  // actionable work (e.g. uncommitted changes, missing tests) it can complete first.
+  const agentActionableMissing = missing.filter(item =>
+    !needsUserAction.some(ua => item.toLowerCase().includes(ua.toLowerCase()) || ua.toLowerCase().includes(item.toLowerCase()))
+  )
+  const shouldContinue = agentActionableMissing.length > 0 || (!requiresHumanAction && missing.length > 0)
   const complete = status === "complete" && missing.length === 0 && confidence >= 0.8 && !requiresHumanAction
 
   let severity: ReflectionAnalysis["severity"] = "NONE"


### PR DESCRIPTION
## Summary

Fixes #56 — Reflection plugin fails to push the agent to continue when session gets stuck on non-coding (ops/personal-assistant) tasks.

## Root Cause

Session `ses_3afa` was a personal assistant session (Gmail cleanup, recruiter replies, Gmail filter creation, MCP configuration). Two bugs caused it to get stuck:

1. **`inferTaskType()` misclassified ops tasks as "coding"** — Text like "Create a filter to label and move emails" matched the `create` coding pattern. "Builds entities and relationships" triggered `build-mention`. This set `requiresTests=true`, `requiresBuild=true`, `requiresPR=true`, `requiresCI=true` — all wrong for an ops task.

2. **`evaluateSelfAssessment()` blocked agent push when `needs_user_action` existed** — Even when the agent had remaining actionable work (uncommitted changes, missing tests), `shouldContinue` was `false` whenever any `needs_user_action` existed. `runReflection()` then returned early with just a toast.

## Changes

- **`inferTaskType()`**: Add ops patterns for personal-assistant/browser keywords (gmail, email, filter, inbox, calendar, linkedin, recruiter, browser, clean up, organize, configure, setup, install) — checked BEFORE coding patterns
- **`buildTaskContext()`**: Make `requiresPR` and `requiresCI` conditional on `taskType === "coding"` (was hardcoded `true`)
- **`evaluateSelfAssessment()`**: Filter agent-actionable missing items from user-action items; set `shouldContinue = true` when agent has work it can do regardless of `needs_user_action`
- **`runReflection()`**: Only skip agent push when `requiresHumanAction && !shouldContinue` (was returning early on any `requiresHumanAction`)
- All fixes mirrored in `reflection-3.test-helpers.ts`
- 6 new unit tests covering ops detection and shouldContinue behavior

## Testing

- `npm run typecheck` — passes
- `npm test` — 166 passed (1 pre-existing whisper timeout unrelated)
- `npm run test:load` — 5/5 pass