### PR TITLE
fix(tts,telegram): skip reflection-injected JSON in final response

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,10 +1,17 @@
 # Plan
 
-Goal: Update reflection-3 to enforce completion gates with GenAI verification (tests, PR/CI, no skipped tests, no direct push).
+## Issue #57: Reflection JSON output visible to user
+
+Goal: Fix TTS and Telegram plugins so they skip reflection-injected messages (self-assessment JSON, feedback) and show/speak the actual user-facing assistant response instead.
 
 Checklist:
-- [x] Update reflection-3 workflow requirements for tests/PR/CI and command evidence
-- [x] Align self-assessment prompt and evaluation logic with new gates
-- [x] Update reflection-3 unit tests for new enforcement
-- [x] Run required tests: npm run typecheck, npm test, npm run test:load, OPENCODE_E2E=1 npm run test:e2e
-- [x] Update plan.md with completion status
+- [x] Identify root cause: reflection-3 injects assessment prompt, agent responds with JSON that becomes last visible message
+- [x] Fix `tts.ts`: add `findReflectionCutoffIndex()` using marker constants, rewrite `extractFinalResponse()` to skip past reflection messages
+- [x] Fix `telegram.ts`: replace fragile `findStaticReflectionPromptIndex()` with marker-based detection, forward scan
+- [x] Add tests in `test/tts.test.ts` for reflection message filtering (9 tests)
+- [x] Run typecheck, test, test:load — all pass (1 flaky Whisper timeout is pre-existing on main)
+- [x] Update plan.md
+- [ ] Commit and create PR for issue #57
+
+## Issue #60: (next)
+- [ ] Read issue and plan work

--- a/telegram.ts
+++ b/telegram.ts
@@ -774,12 +774,22 @@ function isSessionComplete(messages: any[]): boolean {
   return !!(lastAssistant.info?.time as any)?.completed
 }
 
+// Markers injected by the Reflection-3 plugin into the session conversation.
+// Messages containing these markers (and their assistant responses) are internal
+// reflection artifacts — not the real user-facing answer.
+const REFLECTION_SELF_ASSESSMENT_MARKER = "## Reflection-3 Self-Assessment"
+const REFLECTION_FEEDBACK_MARKER = "## Reflection-3:"
+
 function findStaticReflectionPromptIndex(messages: any[]): number {
-  for (let i = messages.length - 1; i >= 0; i--) {
+  for (let i = 0; i < messages.length; i++) {
     const msg = messages[i]
     if (msg.info?.role !== "user") continue
     for (const part of msg.parts || []) {
-      if (part.type === "text" && part.text?.includes("1. **What was the task?**")) {
+      if (
+        part.type === "text" &&
+        (part.text?.includes(REFLECTION_SELF_ASSESSMENT_MARKER) ||
+          part.text?.includes(REFLECTION_FEEDBACK_MARKER))
+      ) {
         return i
       }
     }


### PR DESCRIPTION
## Summary

Fixes #57 — The reflection-3 plugin injects a self-assessment prompt via `promptAsync()`, and the agent responds with raw JSON. This JSON became the last visible assistant message, causing TTS to read it aloud and Telegram to send it as the completion summary.

## Changes

- **`tts.ts`**: Added `findReflectionCutoffIndex()` using `SELF_ASSESSMENT_MARKER` and `FEEDBACK_MARKER` constants from reflection-3. Rewrote `extractFinalResponse()` to find the earliest reflection-injected message and only consider messages before it.
- **`telegram.ts`**: Replaced the fragile `findStaticReflectionPromptIndex()` (which used a hardcoded string `"1. **What was the task?**"`) with marker-based detection using the same constants. Changed from backward to forward scan to correctly handle multiple reflection messages.
- **`test/tts.test.ts`**: Added 9 unit tests covering: normal messages, self-assessment skipping, feedback skipping, all-reflection messages, empty lists, messages without text parts, multiple exchanges before reflection, and cutoff index detection for both markers.

## Testing

- `npm run typecheck` ✅
- `npm test` ✅ (172 passed; 1 flaky Whisper timeout is pre-existing on main)
- `npm run test:load` ✅