### PR TITLE
feat: add 1-line setup script for plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,30 +43,33 @@ This plugin adds a **judge layer** that automatically evaluates task completion 
 ## Quick Install
 
 ```bash
-# Install plugins
+curl -fsSL https://raw.githubusercontent.com/dzianisv/opencode-plugins/main/install.sh | bash
+```
+
+This downloads all plugins to `~/.config/opencode/plugin/`, installs dependencies, and you're ready to go. Restart OpenCode to activate.
+
+**Prerequisites:** [bun](https://bun.sh) (install with `curl -fsSL https://bun.sh/install | bash`)
+
+<details>
+<summary>Manual install</summary>
+
+```bash
 mkdir -p ~/.config/opencode/plugin && \
-curl -fsSL -o ~/.config/opencode/plugin/reflection.ts \
+curl -fsSL -o ~/.config/opencode/plugin/reflection-3.ts \
   https://raw.githubusercontent.com/dzianisv/opencode-plugins/main/reflection-3.ts && \
 curl -fsSL -o ~/.config/opencode/plugin/tts.ts \
   https://raw.githubusercontent.com/dzianisv/opencode-plugins/main/tts.ts && \
 curl -fsSL -o ~/.config/opencode/plugin/telegram.ts \
   https://raw.githubusercontent.com/dzianisv/opencode-plugins/main/telegram.ts && \
-curl -fsSL -o ~/.config/opencode/plugin/worktree-status.ts \
-  https://raw.githubusercontent.com/dzianisv/opencode-plugins/main/worktree-status.ts
+curl -fsSL -o ~/.config/opencode/plugin/worktree.ts \
+  https://raw.githubusercontent.com/dzianisv/opencode-plugins/main/worktree.ts
 
 # Install required dependencies
-cat > ~/.config/opencode/package.json << 'EOF'
-{
-  "dependencies": {
-    "@opencode-ai/plugin": "1.1.36",
-    "@supabase/supabase-js": "^2.49.0"
-  }
-}
-EOF
-cd ~/.config/opencode && bun install
+cd ~/.config/opencode && \
+  bun add @supabase/supabase-js@^2.49.0 && \
+  bun install
 ```
-
-Then restart OpenCode.
+</details>
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# install.sh — 1-line installer for OpenCode plugins
+# Usage: curl -fsSL https://raw.githubusercontent.com/dzianisv/opencode-plugins/main/install.sh | bash
+#
+# Installs: reflection-3.ts, tts.ts, telegram.ts, worktree.ts
+# Targets: macOS and Linux
+set -euo pipefail
+
+REPO="dzianisv/opencode-plugins"
+BRANCH="main"
+BASE_URL="https://raw.githubusercontent.com/${REPO}/${BRANCH}"
+
+PLUGIN_DIR="${HOME}/.config/opencode/plugin"
+CONFIG_DIR="${HOME}/.config/opencode"
+PACKAGE_JSON="${CONFIG_DIR}/package.json"
+
+# Plugins to install
+PLUGINS=(
+  "reflection-3.ts"
+  "tts.ts"
+  "telegram.ts"
+  "worktree.ts"
+)
+
+# Runtime dependencies required by the plugins
+REQUIRED_DEPS='{"@supabase/supabase-js":"^2.49.0"}'
+
+# --- helpers ---
+
+info()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+ok()    { printf '\033[1;32m  ✓\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m  !\033[0m %s\n' "$*" >&2; }
+fail()  { printf '\033[1;31m  ✗\033[0m %s\n' "$*" >&2; exit 1; }
+
+command_exists() { command -v "$1" >/dev/null 2>&1; }
+
+# --- pre-flight checks ---
+
+preflight() {
+  local os
+  os="$(uname -s)"
+  case "$os" in
+    Darwin|Linux) ;;
+    *) fail "Unsupported OS: $os (only macOS and Linux are supported)" ;;
+  esac
+
+  if ! command_exists curl; then
+    fail "curl is required but not found. Please install curl first."
+  fi
+
+  # Check for bun (used by OpenCode for plugin dependency management)
+  if ! command_exists bun; then
+    warn "bun is not installed. It is required by OpenCode to manage plugin dependencies."
+    warn "Install bun: curl -fsSL https://bun.sh/install | bash"
+    fail "Please install bun and re-run this script."
+  fi
+}
+
+# --- package.json management ---
+
+# Merge required dependencies into existing package.json without overwriting.
+# Uses only POSIX tools (no jq required).
+ensure_package_json() {
+  mkdir -p "$CONFIG_DIR"
+
+  if [ ! -f "$PACKAGE_JSON" ]; then
+    # Create fresh package.json
+    cat > "$PACKAGE_JSON" <<'EOF'
+{
+  "dependencies": {
+    "@supabase/supabase-js": "^2.49.0"
+  }
+}
+EOF
+    ok "Created $PACKAGE_JSON"
+    return
+  fi
+
+  # File exists — merge deps using a small inline node/bun script.
+  # We know bun exists (checked in preflight).
+  bun -e "
+    const fs = require('fs');
+    const path = '${PACKAGE_JSON}';
+    const required = ${REQUIRED_DEPS};
+    let pkg;
+    try { pkg = JSON.parse(fs.readFileSync(path, 'utf-8')); } catch { pkg = {}; }
+    if (!pkg.dependencies) pkg.dependencies = {};
+    let changed = false;
+    for (const [k, v] of Object.entries(required)) {
+      if (!pkg.dependencies[k]) { pkg.dependencies[k] = v; changed = true; }
+    }
+    if (changed) {
+      fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + '\n');
+      console.log('Updated dependencies in package.json');
+    } else {
+      console.log('Dependencies already present');
+    }
+  "
+}
+
+# --- main ---
+
+main() {
+  info "Installing OpenCode plugins..."
+  echo
+
+  preflight
+
+  # Create plugin directory
+  mkdir -p "$PLUGIN_DIR"
+  ok "Plugin directory ready: $PLUGIN_DIR"
+
+  # Download each plugin
+  info "Downloading plugins from github.com/${REPO}..."
+  local failed=0
+  for plugin in "${PLUGINS[@]}"; do
+    if curl -fsSL -o "${PLUGIN_DIR}/${plugin}" "${BASE_URL}/${plugin}"; then
+      ok "$plugin"
+    else
+      warn "Failed to download $plugin"
+      failed=$((failed + 1))
+    fi
+  done
+
+  if [ "$failed" -gt 0 ]; then
+    fail "$failed plugin(s) failed to download. Check your network connection."
+  fi
+
+  # Set up dependencies
+  echo
+  info "Setting up dependencies..."
+  ensure_package_json
+
+  # Install with bun
+  (cd "$CONFIG_DIR" && bun install --silent)
+  ok "Dependencies installed"
+
+  # Done
+  echo
+  info "Installation complete!"
+  echo
+  echo "  Installed plugins:"
+  for plugin in "${PLUGINS[@]}"; do
+    echo "    • $plugin"
+  done
+  echo
+  echo "  Restart OpenCode to activate the plugins."
+  echo
+}
+
+main "$@"

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:tts:manual": "node --experimental-strip-types test/tts-manual.ts",
     "test:load": "node --import tsx --test test/plugin-load.test.ts",
     "test:reflection-3": "node --import tsx --test test/reflection-static.eval.test.ts",
+    "test:install": "jest test/install.test.ts --testTimeout=120000",
     "typecheck": "npx tsc --noEmit",
     "install:telegram": "mkdir -p ~/.config/opencode/plugin && cp telegram.ts ~/.config/opencode/plugin/ && node scripts/ensure-deps.js && cd ~/.config/opencode && bun install",
     "install:tts": "mkdir -p ~/.config/opencode/plugin && cp tts.ts ~/.config/opencode/plugin/ && node scripts/ensure-deps.js && (cd ~/.config/opencode && bun install) && bash scripts/setup-coqui.sh",

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -1,0 +1,141 @@
+import { execSync, spawnSync } from 'child_process';
+import { existsSync, readFileSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Integration tests for install.sh
+ *
+ * These tests run the actual install script in an isolated temp directory
+ * by overriding HOME so that ~/.config/opencode is sandboxed.
+ */
+
+const INSTALL_SCRIPT = join(process.cwd(), 'install.sh');
+
+// Create an isolated HOME for each test so we don't touch real config
+function makeTempHome(): string {
+  const dir = join(tmpdir(), `opencode-install-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function runInstall(home: string, env: Record<string, string> = {}): { status: number; stdout: string; stderr: string } {
+  const result = spawnSync('bash', [INSTALL_SCRIPT], {
+    env: {
+      ...process.env,
+      HOME: home,
+      // Ensure PATH includes bun
+      PATH: process.env.PATH || '',
+      ...env,
+    },
+    timeout: 60_000,
+    encoding: 'utf-8',
+  });
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout || '',
+    stderr: result.stderr || '',
+  };
+}
+
+describe('install.sh', () => {
+  let tempHome: string;
+
+  beforeEach(() => {
+    tempHome = makeTempHome();
+  });
+
+  afterEach(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  test('creates plugin directory and downloads all plugins', () => {
+    const { status, stdout, stderr } = runInstall(tempHome);
+    const output = stdout + stderr;
+
+    expect(status).toBe(0);
+
+    // Check plugin directory exists
+    const pluginDir = join(tempHome, '.config', 'opencode', 'plugin');
+    expect(existsSync(pluginDir)).toBe(true);
+
+    // Check all plugin files were downloaded
+    const expectedPlugins = ['reflection-3.ts', 'tts.ts', 'telegram.ts', 'worktree.ts'];
+    for (const plugin of expectedPlugins) {
+      const pluginPath = join(pluginDir, plugin);
+      expect(existsSync(pluginPath)).toBe(true);
+      // Files should have non-trivial content (not empty)
+      const content = readFileSync(pluginPath, 'utf-8');
+      expect(content.length).toBeGreaterThan(100);
+    }
+  }, 60_000);
+
+  test('creates package.json with required dependencies', () => {
+    const { status } = runInstall(tempHome);
+    expect(status).toBe(0);
+
+    const packageJsonPath = join(tempHome, '.config', 'opencode', 'package.json');
+    expect(existsSync(packageJsonPath)).toBe(true);
+
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    expect(pkg.dependencies).toBeDefined();
+    expect(pkg.dependencies['@supabase/supabase-js']).toBeDefined();
+  }, 60_000);
+
+  test('merges into existing package.json without overwriting', () => {
+    // Pre-create a package.json with existing real dependencies
+    const configDir = join(tempHome, '.config', 'opencode');
+    mkdirSync(configDir, { recursive: true });
+    const packageJsonPath = join(configDir, 'package.json');
+    writeFileSync(packageJsonPath, JSON.stringify({
+      dependencies: {
+        '@opencode-ai/plugin': '1.1.65',
+      },
+    }, null, 2));
+
+    const { status } = runInstall(tempHome);
+    expect(status).toBe(0);
+
+    const pkg = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    // Existing deps should be preserved
+    expect(pkg.dependencies['@opencode-ai/plugin']).toBe('1.1.65');
+    // Required dep should be added
+    expect(pkg.dependencies['@supabase/supabase-js']).toBeDefined();
+  }, 60_000);
+
+  test('is idempotent (running twice succeeds)', () => {
+    const result1 = runInstall(tempHome);
+    expect(result1.status).toBe(0);
+
+    const result2 = runInstall(tempHome);
+    expect(result2.status).toBe(0);
+
+    // Plugins should still exist
+    const pluginDir = join(tempHome, '.config', 'opencode', 'plugin');
+    expect(existsSync(join(pluginDir, 'reflection-3.ts'))).toBe(true);
+  }, 120_000);
+
+  test('installs node_modules via bun', () => {
+    const { status } = runInstall(tempHome);
+    expect(status).toBe(0);
+
+    const nodeModulesDir = join(tempHome, '.config', 'opencode', 'node_modules');
+    expect(existsSync(nodeModulesDir)).toBe(true);
+
+    // Supabase should be installed
+    const supabaseDir = join(nodeModulesDir, '@supabase', 'supabase-js');
+    expect(existsSync(supabaseDir)).toBe(true);
+  }, 60_000);
+
+  test('prints success message with plugin list', () => {
+    const { status, stdout, stderr } = runInstall(tempHome);
+    const output = stdout + stderr;
+
+    expect(status).toBe(0);
+    expect(output).toContain('Installation complete');
+    expect(output).toContain('reflection-3.ts');
+    expect(output).toContain('tts.ts');
+    expect(output).toContain('telegram.ts');
+    expect(output).toContain('worktree.ts');
+  }, 60_000);
+});


### PR DESCRIPTION
## Summary
- Add `install.sh` — a single-line `curl | bash` setup script that installs all OpenCode plugins on macOS and Linux
- Update README.md with the 1-line install command
- Add 6 integration tests covering the install script

## Changes
- **`install.sh`**: Downloads `reflection-3.ts`, `tts.ts`, `telegram.ts`, `worktree.ts` to `~/.config/opencode/plugin/`, merges required dependencies into `package.json` (without overwriting existing deps), and runs `bun install`
- **`README.md`**: Replaced the multi-line Quick Install block with a 1-line curl command, kept the manual install in a collapsible details section
- **`test/install.test.ts`**: 6 integration tests — plugin download, package.json creation, dep merge, idempotency, node_modules installation, and success output verification
- **`package.json`**: Added `test:install` script

## Usage
```bash
curl -fsSL https://raw.githubusercontent.com/dzianisv/opencode-plugins/main/install.sh | bash
```

## Testing
- All 6 install tests pass locally (each runs in an isolated temp HOME)
- All 285 existing tests pass
- TypeScript typecheck passes
- Script tested manually in sandboxed temp directory

Closes #71