### PR TITLE
fix(ensure-deps): auto-fix broken @opencode-ai/plugin pre-release versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 # Build artifacts
 *.js
 !jest.config.js
+!scripts/ensure-deps.js
 *.js.map
 *.d.ts
 

--- a/scripts/ensure-deps.js
+++ b/scripts/ensure-deps.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Ensures required dependencies are present in ~/.config/opencode/package.json
+ * OpenCode runs `bun install` at startup to install these dependencies.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+const CONFIG_DIR = join(homedir(), '.config', 'opencode');
+const PACKAGE_JSON_PATH = join(CONFIG_DIR, 'package.json');
+
+// Dependencies required by our plugins
+const REQUIRED_DEPS = {
+  '@supabase/supabase-js': '^2.49.0'
+};
+
+// Minimum stable version for @opencode-ai/plugin
+// Pre-release versions like 0.0.0-main-* are written by dev builds and often
+// get unpublished, breaking `bun install`. This fallback fixes that.
+const PLUGIN_PKG = '@opencode-ai/plugin';
+const PLUGIN_STABLE_VERSION = '^1.2.1';
+
+/**
+ * Returns true if the version string looks like an unstable/pre-release version
+ * that may not exist in the registry (e.g. "0.0.0-main-202602141024").
+ */
+function isUnstablePluginVersion(version) {
+  if (!version || typeof version !== 'string') return true;
+  // Pre-release tags like 0.0.0-main-*, 0.0.0-dev-*, 0.0.0-canary-*
+  if (/^0\.0\.0-/.test(version)) return true;
+  // Exact pinned pre-release (no ^ or ~ prefix) with hyphen tag
+  if (!/^[\^~]/.test(version) && /-/.test(version)) return true;
+  return false;
+}
+
+function ensureDeps() {
+  // Ensure config directory exists
+  if (!existsSync(CONFIG_DIR)) {
+    mkdirSync(CONFIG_DIR, { recursive: true });
+  }
+
+  // Read existing package.json or create default
+  let pkg = { dependencies: {} };
+  if (existsSync(PACKAGE_JSON_PATH)) {
+    try {
+      pkg = JSON.parse(readFileSync(PACKAGE_JSON_PATH, 'utf-8'));
+      if (!pkg.dependencies) {
+        pkg.dependencies = {};
+      }
+    } catch (e) {
+      console.error('Warning: Could not parse existing package.json, creating new one');
+      pkg = { dependencies: {} };
+    }
+  }
+
+  // Add required dependencies if missing
+  let updated = false;
+  for (const [name, version] of Object.entries(REQUIRED_DEPS)) {
+    if (!pkg.dependencies[name]) {
+      pkg.dependencies[name] = version;
+      updated = true;
+      console.log(`Added dependency: ${name}@${version}`);
+    }
+  }
+
+  // Fix broken @opencode-ai/plugin versions (e.g. 0.0.0-main-* from dev builds)
+  const currentPluginVersion = pkg.dependencies[PLUGIN_PKG];
+  if (currentPluginVersion && isUnstablePluginVersion(currentPluginVersion)) {
+    console.log(`Fixing broken ${PLUGIN_PKG} version: ${currentPluginVersion} → ${PLUGIN_STABLE_VERSION}`);
+    pkg.dependencies[PLUGIN_PKG] = PLUGIN_STABLE_VERSION;
+    updated = true;
+  }
+
+  // Write back if updated
+  if (updated) {
+    writeFileSync(PACKAGE_JSON_PATH, JSON.stringify(pkg, null, 2) + '\n');
+    console.log(`Updated ${PACKAGE_JSON_PATH}`);
+  } else {
+    console.log('All required dependencies already present');
+  }
+}
+
+ensureDeps();


### PR DESCRIPTION
## Summary

- Fixes plugin installation failure when OpenCode dev builds write unreleased pre-release versions (e.g. `0.0.0-main-202602141024`) to `~/.config/opencode/package.json`
- `ensure-deps.js` now detects unstable/pre-release `@opencode-ai/plugin` versions and replaces them with a known-good stable version (`^1.2.1`)

## Problem

Running `npm run install:telegram` (or any plugin install) fails with:

```
error: No version matching "0.0.0-main-202602141024" found for specifier "@opencode-ai/plugin" (but package exists)
```

This happens because OpenCode's dev/nightly builds write pre-release version strings into the config `package.json`, and those versions get unpublished from npm.

## Solution

Added `isUnstablePluginVersion()` check to `scripts/ensure-deps.js` that catches:
- `0.0.0-main-*`, `0.0.0-dev-*`, `0.0.0-canary-*` pre-release tags
- Exact pinned pre-release versions without `^`/`~` range prefix

When detected, the version is replaced with `^1.2.1` (latest stable) and the user sees:
```
Fixing broken @opencode-ai/plugin version: 0.0.0-main-202602141024 → ^1.2.1
```

## Testing

- All 180 unit tests pass
- Verified script fixes the broken version in real `~/.config/opencode/package.json`
- `npm run install:telegram` succeeds after fix