### PR TITLE
fix(telegram,reflection): filter self-assessment JSON and return post-feedback responses

### DIFF
--- a/reflection-3.ts
+++ b/reflection-3.ts
@@ -655,9 +655,11 @@ I'm verifying the task completion and quality standards. Please provide a self-a
 - Required checks: ${requirements.join("; ")}
 - Detected signals: ${signalSummary}
 
-${agents ? `**Project Instructions:**\n${agents.slice(0, 800)}\n\n` : ""}**Respond with JSON only** - provide a structured self-assessment using this exact format:
+${agents ? `**Project Instructions:**\n${agents.slice(0, 800)}\n\n` : ""}**IMPORTANT: Your entire response must be valid JSON and nothing else.**
+Do not include any explanation, commentary, markdown formatting, or code fences.
+Do not write anything before or after the JSON object.
+Output ONLY a single JSON object using this exact schema:
 
-\`\`\`json
 {
   "task_summary": "brief description of what was done",
   "task_type": "feature|bugfix|refactor|docs|research|ops|other",
@@ -687,7 +689,6 @@ ${agents ? `**Project Instructions:**\n${agents.slice(0, 800)}\n\n` : ""}**Respo
   "stuck": false,
   "alternate_approach": "describe if needed"
 }
-\`\`\`
 
 **Verification Rules:**
 - If coding work is complete, confirm tests ran after the latest changes and passed
@@ -696,7 +697,9 @@ ${agents ? `**Project Instructions:**\n${agents.slice(0, 800)}\n\n` : ""}**Respo
 - Tests cannot be skipped or marked as flaky/not important
 - Direct pushes to main/master are not allowed; require a PR instead
 - If stuck, propose an alternate approach
-- If you need user action (auth, 2FA, credentials), list it in needs_user_action`
+- If you need user action (auth, 2FA, credentials), list it in needs_user_action
+
+Remember: respond with ONLY the JSON object. No other text.`
 }
 
 function parseSelfAssessmentJson(text: string | null | undefined): SelfAssessment | null {


### PR DESCRIPTION
## Summary

- **telegram.ts**: `extractFinalResponse()` now correctly returns the agent's response *after* reflection feedback, not the stale pre-reflection one
- **telegram.ts**: New `isSelfAssessmentJson()` filter prevents internal reflection JSON (`{"status":"complete","confidence":0.9,...}`) from leaking into Telegram messages
- **reflection-3.ts**: Strengthened self-assessment prompt to enforce strict JSON-only output (no code fences, no prose)

## Problem

When reflection marked a task INCOMPLETE and gave feedback, the agent would do more work (e.g., "Added tests, all passing now"). But `extractFinalResponse()` always returned the *pre-reflection* response because it used `cutoffIndex - 1` as a hard ceiling. Additionally, the LLM's self-assessment JSON response could leak into Telegram when other filtering failed.

## Changes

### telegram.ts
- **`extractFinalResponse()`**: Rewritten with 3-tier logic:
  1. If no reflection → return last assistant message (unchanged)
  2. If reflection gave feedback → return the last non-JSON assistant response *after* the final feedback marker
  3. Fallback → return pre-reflection response
- **`isSelfAssessmentJson()`**: Detects self-assessment JSON by checking for `status` + (`confidence` | `evidence` | `task_summary`) fields; handles both pure JSON and prose-wrapped JSON
- **`findLastReflectionFeedbackIndex()`**: Finds the last `## Reflection-3:` feedback marker for multi-round reflection

### reflection-3.ts
- Replaced `**Respond with JSON only**` + code fences with explicit instructions: "Your entire response must be valid JSON and nothing else. Do not include any explanation, commentary, markdown formatting, or code fences."

### Tests
- 13 new unit tests (75 total, all passing)
- Covers: self-assessment JSON detection, multi-round feedback, prose-wrapped JSON, edge cases