### PR TITLE
test(eval): integrate telegram filtering into reflection eval test

### DIFF
--- a/telegram.test-helpers.ts
+++ b/telegram.test-helpers.ts
@@ -104,6 +104,14 @@ export function isSessionComplete(messages: any[]): boolean {
 }
 
 /**
+ * Returns true if the session contains reflection-injected messages.
+ * Mirrors telegram.ts:hasReflectionContent
+ */
+export function hasReflectionContent(messages: any[]): boolean {
+  return findStaticReflectionPromptIndex(messages) !== -1
+}
+
+/**
  * Find the index of the first user message that contains a Reflection-3
  * self-assessment or feedback marker.
  * Mirrors telegram.ts:findStaticReflectionPromptIndex


### PR DESCRIPTION
## Summary
- Deploy `telegram.ts` alongside `reflection-3.ts` in the eval test setup so both plugins are exercised during E2E runs
- Add a new test case that verifies `extractFinalResponse` correctly filters reflection artifacts (self-assessment JSON, feedback messages) from actual session messages
- Export `hasReflectionContent()` from `telegram.test-helpers.ts`
- Save `telegramFilter` results to `evaluation-results.json`

## Cleanup
- Remove all decorative banner output (`===`, `---`, bold/italic styled lines)
- Replace verbose `console.log` announcements with concise `[tag] key=value` format

## Testing
- 75/75 unit tests passing (`npx jest test/telegram.unit.test.ts`)