### PR TITLE
fix(plugins): guard against NotFoundError from deleted sessions

### DIFF
--- a/tts.ts
+++ b/tts.ts
@@ -2084,8 +2084,9 @@ export const TTSPlugin: Plugin = async ({ client, directory }) => {
               await debugLog(`Session directory: ${sessionDirectory}`)
             }
           } catch (e: any) {
-            // If we can't get session info, continue anyway
-            await debugLog(`Could not get session info: ${e?.message || e}`)
+            // Session was deleted (e.g., reflection judge session cleanup race) — skip silently
+            await debugLog(`Session not found (likely deleted), skipping: ${e?.message || e}`)
+            return
           }
           
           const { data: messages } = await client.session.messages({ path: { id: sessionId } })


### PR DESCRIPTION
## Summary
- Fix unhandled `NotFoundError` caused by race condition between reflection's judge session cleanup and telegram/tts plugin event handlers
- Guard all `session.get()` and `session.messages()` calls against deleted sessions
- Prevent infinite retry loops when forwarding Telegram replies to deleted sessions

## Root Cause
When reflection creates and deletes judge/classifier sessions, OpenCode emits `session.idle` events for those sessions. By the time telegram or tts plugins process the event and call `session.get()`, the session is already deleted, causing `NotFoundError` at `src/storage/storage.ts:205:19`.

## Changes
**telegram.ts:**
- Wrap `session.get()` and `session.messages()` in inner try-catch blocks that silently skip deleted sessions
- Wrap `session.updated` handler in try-catch (was completely unguarded)
- Verify session exists before forwarding Telegram replies (both realtime subscription and polling)
- Mark replies to deleted sessions as processed to prevent infinite retry loops

**tts.ts:**
- Bail early if `session.get()` fails instead of continuing to `session.messages()` which would also fail