### PR TITLE
fix(reflection,tts): guard all session API calls against NotFoundError

### DIFF
--- a/tts.ts
+++ b/tts.ts
@@ -2089,7 +2089,15 @@ export const TTSPlugin: Plugin = async ({ client, directory }) => {
             return
           }
           
-          const { data: messages } = await client.session.messages({ path: { id: sessionId } })
+          let messages: any[] | undefined
+          try {
+            const { data } = await client.session.messages({ path: { id: sessionId } })
+            messages = data
+          } catch (e: any) {
+            // Session was deleted between session.get and session.messages (TOCTOU race)
+            await debugLog(`Session messages not found (likely deleted), skipping: ${e?.message || e}`)
+            return
+          }
           await debugLog(`Got ${messages?.length || 0} messages`)
           
           if (!messages || messages.length < 2) {


### PR DESCRIPTION
## Summary

- Wraps all 5 unguarded `client.session.messages()` and `client.session.create()` calls in `reflection-3.ts` with individual try-catch blocks
- Fixes a TOCTOU race in `tts.ts` where `session.messages()` could throw after a successful `session.get()` if the session was deleted between the two calls
- Complements PR #92 which only partially addressed the issue in `telegram.ts` and `tts.ts`

## Problem

After restarting OpenCode, `NotFoundError` from `storage.ts:205` corrupts the TUI. The root cause is in `reflection-3.ts` where session API calls inside a `try/finally` block (with **no catch**) throw when a session gets deleted between events — e.g., by reflection's own judge session cleanup.

## Changes

**reflection-3.ts** (5 call sites):
- `session.messages()` at initial fetch — returns early on error
- `session.messages()` mid-reflection re-check — sets lastReflectedMsgId, returns early
- `session.messages()` pre-feedback re-check — sets lastReflectedMsgId, returns early  
- `session.create()` for classifier session — returns null on error
- `session.create()` for judge session — returns null on error

**tts.ts** (1 call site):
- `session.messages()` between `session.get` and message processing — returns early with debug log

## Testing

All existing tests pass (66 reflection unit tests, 39 reflection integration tests, 75 telegram tests, 32 github tests).