### PR TITLE
fix(reflection): guard buildEscalatingFeedback against null/undefined verdict

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,15 @@ For debug/diagnostic logging, write to log files instead:
 
 Test files (`test/*.ts`) may use `console.log` for test output.
 
+### Always run tests before finishing
+
+Before considering any task complete, you MUST:
+
+1. **Run unit tests**: `npm test` — all tests must pass.
+2. **Run prompt evals**: `npm run eval:judge`, `npm run eval:stuck`, `npm run eval:compression` — all evals must pass.
+3. If tests or evals fail, fix the issue and re-run until they pass.
+4. Never commit or create a PR with failing tests.
+
 ## References
 - `docs/reflection.md`
 - `docs/tts.md`


### PR DESCRIPTION
## Summary

- Fix `TypeError: undefined is not an object` crash in `buildEscalatingFeedback` when `verdict` is `null` or `undefined`
- Normalize verdict with `safeVerdict = verdict ?? {}` and pre-extract fields with `Array.isArray()` guards
- Harden `analysis.missing[0]` access at line 1372 with array check
- Add 8 unit tests covering null, undefined, partial, and empty verdict edge cases
- Add "always run tests before finishing" rule to AGENTS.md

## Testing

- All unit tests pass (322 total: 317 passed, 5 skipped)
- All prompt evals pass: `eval:judge` (23/23), `eval:stuck` (12/12), `eval:compression` (12/12)