### PR TITLE
fix: guard detectPlanningLoop against non-array messages input

### DIFF
--- a/reflection-3.ts
+++ b/reflection-3.ts
@@ -221,6 +221,9 @@ export function detectPlanningLoop(messages: any[]): {
   writeCount: number
   totalTools: number
 } {
+  if (!Array.isArray(messages)) {
+    return { detected: false, readCount: 0, writeCount: 0, totalTools: 0 }
+  }
   let readCount = 0
   let writeCount = 0
   let totalTools = 0


### PR DESCRIPTION
## Summary
- Adds `Array.isArray(messages)` guard at the top of `detectPlanningLoop` to prevent `TypeError: {} is not iterable` when the OpenCode framework passes `{}` instead of an array
- This was the root cause of 500 errors on every HTTP request to the server, blocking E2E test suites

## Context
PR #106 added guards at the 4 `client.session.messages()` call sites, but `detectPlanningLoop` itself could still receive non-array input from the plugin framework's internal call path (`src/plugin/index.ts:90`).