### PR TITLE
fix(reflection): detect planning loops via GenAI prompts, fix inferTaskType misclassification (#115)

### DIFF
--- a/evals/prompts/stuck-detection.txt
+++ b/evals/prompts/stuck-detection.txt
@@ -28,6 +28,7 @@ Determine if the agent is stuck and needs a nudge to continue.
 - Agent shows test results with "passed" or "✓"  
 - Agent's response indicates task fulfilled: "I've added", "I've fixed", "The X now works"
 - No pending work mentioned (no "Next I will...", "Still need to...")
+- IMPORTANT: If the user's task requires code changes (fix, implement, add, create, build, refactor), message_completed is true, and the Tool Calls show ONLY read operations (read, glob, grep, git log/status/diff, webfetch, task/explore) with NO write operations (edit, write, bash with build/test/commit, PR creation), the task is NOT complete — classify as genuinely_stuck with stuck=true. Analyzing or recommending changes is not the same as implementing them.
 → reason: "complete"
 
 ### 3. WAITING FOR USER

--- a/evals/stuck-detection.yaml
+++ b/evals/stuck-detection.yaml
@@ -299,4 +299,49 @@ tests:
           const result = JSON.parse(json[0]);
           return result.stuck === false || result.shouldNudge === false;
 
+  - description: "Planning loop - agent only read/explored, never wrote code (issue #115)"
+    vars:
+      time_since_activity: "120"
+      message_completed: "true"
+      output_tokens: "3500"
+      last_user_message: "https://github.com/VibeTechnologies/VibeWebAgent/issues/513 - Investigate and fix the MCP WebSocket connection failure"
+      last_assistant_response: |
+        ## Root Cause Analysis
+        
+        After investigating the codebase extensively, I found that the MCP WebSocket connection
+        failure is caused by a race condition in the connection manager. The `connectToServer`
+        function doesn't properly handle the case where the server closes the connection
+        during the handshake phase.
+        
+        ### Recommendations
+        1. Add retry logic with exponential backoff
+        2. Handle the WebSocket close event during handshake
+        3. Add connection state tracking
+        
+        I've identified all the relevant files and understand the issue thoroughly.
+        The fix should be straightforward to implement.
+      tool_calls: |
+        github_issue_read (get issue #513)
+        task (explore codebase)
+        read (src/mcp/connection.ts)
+        read (src/mcp/websocket.ts)
+        glob (src/**/*.ts)
+        grep (connectToServer)
+        read (src/mcp/manager.ts)
+        read (src/mcp/types.ts)
+        bash (git log --oneline -10)
+        read (src/mcp/retry.ts)
+        webfetch (docs reference)
+        read (package.json)
+        task (explore more files)
+        read (src/mcp/handler.ts)
+        read (src/utils/logger.ts)
+    assert:
+      - type: javascript
+        value: |
+          const json = output.match(/\{[\s\S]*\}/);
+          if (!json) return false;
+          const result = JSON.parse(json[0]);
+          return result.stuck === true && result.reason === "genuinely_stuck";
+
 outputPath: ./evals/results/stuck-detection-latest.json


### PR DESCRIPTION
## Summary

Fixes #115 — sessions where the agent only reads/explores files but never implements code changes were being marked as "complete" by the reflection plugin.

### Root Cause (two interacting bugs)

1. **`inferTaskType()` misclassification**: The regex `research|investigate|analyze|compare|evaluate|study` matched before `fix|bug|issue|error|regression`. Tasks containing both "investigate" AND "fix" were classified as `"research"` instead of `"coding"`.

2. **Research tasks bypass ALL workflow gates**: When `taskType === "research"`, `requiresTests`, `requiresBuild`, `requiresPR`, and `requiresCI` are all set to `false`. With no requirements, `evaluateSelfAssessment()` finds `missing.length === 0`, and if the LLM returns `status: "complete"`, the task is marked complete without feedback.

3. **No planning loop detection in GenAI prompts**: The self-assessment and judge prompts had no rule checking whether the agent actually made code changes vs only reading/exploring.

### Changes

- **`inferTaskType()` refactored** — prioritizes coding action keywords (`fix`, `implement`, `add`, `create`, etc.) over research classification; adds GitHub issue URL detection
- **Planning loop detection via GenAI prompts** — added "PLANNING LOOP CHECK" rules to self-assessment prompt and judge/analyze prompt telling the LLM to set `status: "in_progress"` / `complete: false` when a coding task shows only read operations
- **Stuck-detection eval prompt enhanced** — added planning loop rule scoped to `message_completed: true` (avoids interfering with "WORKING" priority when tools are still running)
- **Mirror fix in test-helpers** — `inferTaskType()` in `reflection-3.test-helpers.ts` updated identically
- **Unit tests** — 5 new tests for `inferTaskType`, `evaluateSelfAssessment`, `detectPlanningLoop`, `buildEscalatingFeedback`
- **Eval test case** — new stuck-detection case: "Planning loop - agent only read/explored, never wrote code"

### Design Decision

Per [feedback on PR #114](https://github.com/dzianisv/opencode-plugins/pull/114#issuecomment-3904965494), planning loop detection is done **entirely via GenAI prompts**, not mechanical heuristics or counters. The `detectPlanningLoop()` function still exists and is used for `buildEscalatingFeedback()` (choosing feedback text style), but does NOT mechanically override `analysis.complete`.

### Test Results

| Suite | Result |
|-------|--------|
| `npm test` | 320 pass, 5 skipped |
| `eval:judge` | 23/23 (100%) |
| `eval:stuck` | 18/18 (100%) |
| `eval:compression` | 12/12 (100%) |