### PR TITLE
feat(reflection): add cross-model review between claude-opus and gpt-codex

### DIFF
--- a/docs/reflection.md
+++ b/docs/reflection.md
@@ -78,6 +78,97 @@ flowchart TD
   Done -->|no| Feedback[Prompt feedback to continue]
 ```
 
+### Detailed State Graph
+
+```
+session.idle fires
+    |
+    v
++---------------------------+
+| GUARD CHECKS              |
+| - Is judge/classifier?    |--yes--> SKIP
+| - Is plan mode?           |--yes--> SKIP
+| - Was ESC-aborted?        |--yes--> SKIP (10s cooldown)
+| - Same user msg already   |--yes--> SKIP
+|   reflected?              |
++----------+----------------+
+           | no
+           v
++---------------------------+
+| A) BUILD TASK CONTEXT     |
+| - Collect user messages   |
+| - Infer task type         |
+|   (coding/docs/research/  |
+|    ops/other)             |
+| - Detect repo signals     |
+|   (package.json scripts,  |
+|    test/ dir)             |
+| - Extract tool commands   |
+| - Determine workflow      |
+|   requirements            |
++----------+----------------+
+           v
++---------------------------+
+| B) SELF-ASSESSMENT        |
+| Request agent to produce  |
+| JSON with evidence:       |
+| - Did you complete task?  |
+| - Did you run tests?      |
+| - Did you create PR?      |
+| - Did CI pass?            |
+| - Are you stuck?          |
+| (runs in ephemeral        |
+|  session, not main)       |
++----------+----------------+
+           v
++---------------------------+
+| C) PARSE & EVALUATE      |
+| Parse JSON --success--> evaluateSelfAssessment()
+|            +--fail---> Judge LLM fallback
+|                        |
+| Workflow gate checks:  |
+| 1. Tests ran? Passed?  |
+|    Ran AFTER changes?  |
+|    Not skipped/flaky?  |
+| 2. Build ran? Passed?  |
+| 3. PR created? URL?    |
+|    Evidence (gh pr)?   |
+| 4. CI checked? Passed? |
+|    Evidence (gh pr     |
+|    checks)?            |
+| 5. No push to main?   |
+| 6. Planning loop check |
++----------+----------------+
+           v
++---------------------------+
+| D) VERDICT                |
+| Write .reflection/        |
+|   verdict_<session>.json  |
+|                           |
+| Three outcomes:           |
+| COMPLETE      --> Toast success, done
+| NEEDS USER    --> Toast warning, done
+| INCOMPLETE    --> Continue below
++----------+----------------+
+           | incomplete
+           v
++---------------------------+
+| E) FEEDBACK + ROUTING     |
+| - Classify task category  |
+|   (backend/arch/frontend) |
+| - Build escalating        |
+|   feedback (attempt N/5)  |
+| - Inject feedback into    |
+|   session (optionally     |
+|   with model routing)     |
+| - Agent continues work    |
++---------------------------+
+           |
+           v
+     (session.idle fires again --> loop back to top,
+      up to MAX_ATTEMPTS=5)
+```
+
 ## Files and Artifacts
 - `<workspace>/.reflection/verdict_<session>.json` (signal for TTS/Telegram)
 - `<workspace>/.reflection/<session>_<timestamp>.json` (full analysis record)

--- a/reflection-3.test-helpers.ts
+++ b/reflection-3.test-helpers.ts
@@ -310,6 +310,11 @@ export interface RoutingConfig {
   models: Record<RoutingCategory, string>
 }
 
+export interface ModelSpecParts {
+  providerID: string
+  modelID: string
+}
+
 
 export function parseRoutingFromYaml(content: string): RoutingConfig {
   const DEFAULT_ROUTING_CONFIG: RoutingConfig = {
@@ -374,6 +379,27 @@ export function getRoutingModel(config: RoutingConfig, category: RoutingCategory
   const modelID = parts.slice(1).join("/") || ""
   if (!providerID || !modelID) return null
   return { providerID, modelID }
+}
+
+export function parseModelSpec(modelSpec: string | null | undefined): ModelSpecParts | null {
+  if (typeof modelSpec !== "string") return null
+  const trimmed = modelSpec.trim()
+  if (!trimmed) return null
+  const parts = trimmed.split("/")
+  if (parts.length < 2) return null
+  const providerID = parts[0] || ""
+  const modelID = parts.slice(1).join("/") || ""
+  if (!providerID || !modelID) return null
+  return { providerID, modelID }
+}
+
+export function getCrossReviewModelSpec(modelSpec: string | null | undefined): string | null {
+  const parsed = parseModelSpec(modelSpec)
+  if (!parsed) return null
+  const modelID = parsed.modelID.toLowerCase()
+  if (modelID === "claude-opus-4.6") return "github-copilot/gpt-5.2-codex"
+  if (modelID === "gpt-5.2-codex") return "github-copilot/claude-opus-4.6"
+  return null
 }
 
 const FEEDBACK_MARKER = "## Reflection-3:"

--- a/telegram.test-helpers.ts
+++ b/telegram.test-helpers.ts
@@ -68,6 +68,8 @@ const REFLECTION_FEEDBACK_MARKER = "## Reflection-3:"
 // Sessions containing these are NOT user-facing and must never be posted to Telegram.
 export const INTERNAL_SESSION_MARKERS = [
   "ANALYZE REFLECTION-3",   // reflection-3 judge sessions
+  "SELF-ASSESS REFLECTION-3", // reflection-3 self-assessment sessions
+  "REVIEW REFLECTION-3 COMPLETION", // reflection-3 cross-model review sessions
   "CLASSIFY TASK ROUTING",  // reflection-3 task routing classifier
   "TASK VERIFICATION",      // legacy reflection judge sessions
   "You are a judge",        // legacy judge sessions

--- a/telegram.ts
+++ b/telegram.ts
@@ -777,6 +777,8 @@ async function transcribeAudio(
 // Sessions containing these are NOT user-facing and must never be posted to Telegram.
 const INTERNAL_SESSION_MARKERS = [
   "ANALYZE REFLECTION-3",   // reflection-3 judge sessions
+  "SELF-ASSESS REFLECTION-3", // reflection-3 self-assessment sessions
+  "REVIEW REFLECTION-3 COMPLETION", // reflection-3 cross-model review sessions
   "CLASSIFY TASK ROUTING",  // reflection-3 task routing classifier
   "TASK VERIFICATION",      // legacy reflection judge sessions
   "You are a judge",        // legacy judge sessions

--- a/test/reflection-3.unit.test.ts
+++ b/test/reflection-3.unit.test.ts
@@ -7,6 +7,8 @@ import {
   parseRoutingFromYaml,
   getRoutingModel,
   buildEscalatingFeedback,
+  parseModelSpec,
+  getCrossReviewModelSpec,
   RoutingConfig
 } from "../reflection-3.test-helpers.ts"
 import { detectPlanningLoop } from "../reflection-3.ts"
@@ -635,5 +637,30 @@ routing:
       }
       assert.strictEqual(getRoutingModel(config, "backend"), null)
     })
+  })
+})
+
+describe("cross-model review routing", () => {
+  it("parses model spec into provider/model parts", () => {
+    const parsed = parseModelSpec("github-copilot/claude-opus-4.6")
+    assert.deepStrictEqual(parsed, { providerID: "github-copilot", modelID: "claude-opus-4.6" })
+  })
+
+  it("returns null for invalid model specs", () => {
+    assert.strictEqual(parseModelSpec(""), null)
+    assert.strictEqual(parseModelSpec("just-a-name"), null)
+    assert.strictEqual(parseModelSpec(undefined), null)
+  })
+
+  it("selects cross-review model for opus", () => {
+    assert.strictEqual(getCrossReviewModelSpec("github-copilot/claude-opus-4.6"), "github-copilot/gpt-5.2-codex")
+  })
+
+  it("selects cross-review model for gpt-5.2-codex", () => {
+    assert.strictEqual(getCrossReviewModelSpec("github-copilot/gpt-5.2-codex"), "github-copilot/claude-opus-4.6")
+  })
+
+  it("returns null for unrelated models", () => {
+    assert.strictEqual(getCrossReviewModelSpec("github-copilot/gemini-3-pro-preview"), null)
   })
 })

--- a/test/telegram-session-filter.test.ts
+++ b/test/telegram-session-filter.test.ts
@@ -54,6 +54,22 @@ describe("isJudgeSession", () => {
     expect(isJudgeSession(messages)).toBe(true)
   })
 
+  it("detects reflection-3 self-assessment sessions (SELF-ASSESS REFLECTION-3)", () => {
+    const messages = [
+      msg("user", "SELF-ASSESS REFLECTION-3\n\nPlease evaluate your own work..."),
+      msg("assistant", '{"status": "complete", "confidence": 0.9}', { completed: true }),
+    ]
+    expect(isJudgeSession(messages)).toBe(true)
+  })
+
+  it("detects reflection-3 cross-model review sessions (REVIEW REFLECTION-3 COMPLETION)", () => {
+    const messages = [
+      msg("user", "REVIEW REFLECTION-3 COMPLETION\n\nYou are reviewing another model's completion verdict..."),
+      msg("assistant", "The self-assessment appears justified. No gaps found.", { completed: true }),
+    ]
+    expect(isJudgeSession(messages)).toBe(true)
+  })
+
   it("detects reflection-3 routing classifier sessions (CLASSIFY TASK ROUTING)", () => {
     const messages = [
       msg("user", "CLASSIFY TASK ROUTING\n\nYou are classifying a task into one routing category.\n\nTask summary: Fix the login bug"),

--- a/tts.ts
+++ b/tts.ts
@@ -1989,6 +1989,8 @@ export const TTSPlugin: Plugin = async ({ client, directory }) => {
   // Markers used by reflection plugins in internal evaluation sessions.
   const INTERNAL_SESSION_MARKERS = [
     "ANALYZE REFLECTION-3",   // reflection-3 judge sessions
+    "SELF-ASSESS REFLECTION-3", // reflection-3 self-assessment sessions
+    "REVIEW REFLECTION-3 COMPLETION", // reflection-3 cross-model review sessions
     "CLASSIFY TASK ROUTING",  // reflection-3 task routing classifier
     "TASK VERIFICATION",      // legacy reflection judge sessions
     "You are a judge",        // legacy judge sessions


### PR DESCRIPTION
## Summary

- When reflection self-assessment returns `complete`, the plugin now invokes the **opposite frontier model** (claude-opus-4.6 ↔ gpt-5.2-codex) in an ephemeral session to independently review the changes. The cross-review result is saved in the `.reflection/<session>_<timestamp>.json` artifact.
- Adds a detailed **ASCII state graph** documenting the full reflection flow to both `docs/reflection.md` and `README.md`.
- Adds missing `INTERNAL_SESSION_MARKERS` entries (`SELF-ASSESS REFLECTION-3`, `REVIEW REFLECTION-3 COMPLETION`) to `tts.ts`, `telegram.ts`, and `telegram.test-helpers.ts` so those plugins correctly skip all reflection-internal sessions.

## Changes

| File | What |
|------|------|
| `reflection-3.ts` | `parseModelSpec()`, `getCrossReviewModelSpec()`, `runCrossModelReview()`, wired into completion path, updated `isJudgeSession()` |
| `reflection-3.test-helpers.ts` | Exported test-safe copies of `parseModelSpec` and `getCrossReviewModelSpec` |
| `tts.ts` / `telegram.ts` / `telegram.test-helpers.ts` | Added 2 new markers to `INTERNAL_SESSION_MARKERS` |
| `test/reflection-3.unit.test.ts` | Unit tests for cross-model routing logic |
| `test/telegram-session-filter.test.ts` | Tests for the new session markers |
| `docs/reflection.md` / `README.md` | ASCII state graph diagram |

## Testing

- `npm test` — 326 passed, 5 skipped, 8 suites green
- `npm run eval:judge` — 23/23 passed
- `npm run eval:stuck` — 12/13 passed (1 pre-existing borderline case)
- `npm run eval:compression` — 12/12 passed