### PR TITLE
docs: archive notice — superseded by agents-supervisor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # OpenCode Plugins
 
+> ⚠️ **Archived — superseded by [dzianisv/agents-supervisor](https://github.com/dzianisv/agents-supervisor).**
+> The reflection/supervisor plugin was extracted into its own repo (rebranded
+> "supervisor"): dual-runtime (Claude Code + OpenCode), one shared core, plus
+> `/supervisor:train` (learn from your sessions) and a goal loop. Use that repo.
+> This repo is kept read-only for history; branch-cleanup recovery notes live in
+> [`docs/branch-cleanup-2026-06.md`](docs/branch-cleanup-2026-06.md).
+
 **78% of AI coding agent stops are premature.** This is a judge layer that catches them.
 
 [![Tests](https://github.com/dzianisv/opencode-plugins/actions/workflows/test.yml/badge.svg)](https://github.com/dzianisv/opencode-plugins/actions/workflows/test.yml)

--- a/docs/branch-cleanup-2026-06.md
+++ b/docs/branch-cleanup-2026-06.md
@@ -1,0 +1,25 @@
+# opencode-plugins branch cleanup — recovery manifest (2026-06-08)
+
+Deleted during supervisor extraction cleanup. To restore any branch:
+`git push origin <sha>:refs/heads/<branch>`
+
+## Deleted — merged into main (zero loss, also in main history)
+- eval/expand-coverage                                104335a
+- issue-120-reflection-toast                          8fefc01
+- issue-123-reflection-next-steps                     b0f062e
+- issue-74-plan-mode-reflection                       7422543
+- issue-80-reflection-loop-prevention                 85d7a44
+
+## Deleted — harvested into dzianisv/agents-supervisor (value preserved there)
+- feat/supervisor-mode                                2c7b165   # goal loop → agents-supervisor core/goal.mjs + both runtimes
+- fix/115-reflection-stuck-research-misclassification ee13878   # folded into core/patterns.json (analysis_no_implementation, stuck guidance)
+
+## Deleted — local redundant copies (identical to remote, kept on remote)
+- (local) issue-135-auto-review                       4fe631d
+- (local) issue-136-package-auto-review               9aa93b9
+
+## KEPT — unique unmerged work, not harvested
+- feat/cross-model-review                             b4a5718   # cross-model consensus verdict (not ported)
+- fix/opencode-worktree-sanitize-branch-name          1afc6b3   # worktree plugin fix (unrelated to supervisor)
+- issue-135-auto-review                               4fe631d   # auto-review CI work
+- issue-136-package-auto-review                       9aa93b9   # auto-review packaging (broader than the antipattern bit folded in)


### PR DESCRIPTION
## What

Records the 2026-06-08 branch cleanup that followed extracting the reflection/supervisor
plugin into its own repo, **dzianisv/agents-supervisor**.

Adds `docs/branch-cleanup-2026-06.md` — the recovery manifest with every deleted
branch's SHA, so anything can be restored with:

```
git push origin <sha>:refs/heads/<branch>
```

## Branches deleted (recorded in the manifest)
- **Merged into main** (zero loss): `eval/expand-coverage`, `issue-120-reflection-toast`, `issue-123-reflection-next-steps`, `issue-74-plan-mode-reflection`, `issue-80-reflection-loop-prevention`
- **Harvested into agents-supervisor**: `feat/supervisor-mode` (goal loop → `core/goal.mjs`), `fix/115-reflection-stuck-research-misclassification` (folded into `core/patterns.json`)

## Branches kept (unique, unmerged, not harvested)
`feat/cross-model-review`, `fix/opencode-worktree-sanitize-branch-name`, `issue-135-auto-review`, `issue-136-package-auto-review`

## Note
This PR does **not** remove the reflection plugin from this repo — `tts.ts`/`telegram.ts`
still consume its `.reflection/verdict_*.json` output. Removing the plugin is a separate,
larger change (rewire those consumers first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)